### PR TITLE
Solving a bug on CentOS install

### DIFF
--- a/ext/nokogiri_ext_xmlsec/extconf.rb
+++ b/ext/nokogiri_ext_xmlsec/extconf.rb
@@ -7,7 +7,7 @@ end
 barf unless have_header('ruby.h')
 
 pkg_config('xmlsec1')
-
+$CFLAGS << " " + `xmlsec1-config  --cflags`.strip
 $CFLAGS << " -fvisibility=hidden"
 
 if $CFLAGS =~ /\-DXMLSEC_CRYPTO=\\\\\\"openssl\\\\\\"/


### PR DESCRIPTION
I found an issue preventing nokogiri-xmlsec-me-harder from working on CentOS. Found a fix too.

A simple one actually... just adding config flags that I get directly from xmlsec-config command, it sets things like where to find config files (location depends on Unix distribution).

Let me know if I have to add more information in my PR or add some things in my code. 

repro steps: try and compile on CentOS